### PR TITLE
Upgrading Sentry SDK and fixing error when SentryService does not exist

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Raven = require('raven');
+const Sentry = require('@sentry/node');
 const assert = require('assert');
 
 module.exports = app => {
@@ -8,7 +8,9 @@ module.exports = app => {
 
   assert(config.dsn, '[egg-sentry][config] dsn is required');
 
-  Raven.config(config.dsn).install();
+  Sentry.init({
+    dsn: config.dsn,
+  });
 
   app.on('error', (e, ctx) => {
     const {
@@ -19,11 +21,9 @@ module.exports = app => {
       return;
     }
 
-    Raven.setContext({
-      user,
-      extra,
-    });
-    Raven.captureException(e, {
+    Sentry.setUser(user);
+    Sentry.setExtras(extra);
+    Sentry.captureException(e, {
       tags,
     });
   });

--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ module.exports = app => {
   app.on('error', (e, ctx) => {
     const {
       user = {}, extra = {}, tags = {}, judgeError = () => true,
-    } = new app.serviceClasses.sentry(ctx);
+    } = app.serviceClasses.sentry ? new app.serviceClasses.sentry(ctx) : {};
 
     if (!judgeError(e)) {
       return;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "egg-plugin"
   ],
   "dependencies": {
-    "raven": "^2.2.1"
+    "@sentry/node": "^6.2.3"
   },
   "devDependencies": {
     "autod": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "url": "git+https://github.com/freebyron/egg-sentry.git"
   },
   "bugs": {
-    "url": "https://github.com/eggjs/egg/issues"
+    "url": "https://github.com/freebyron/egg-sentry/issues"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "homepage": "https://github.com/eggjs/egg-sentry#readme",
+  "homepage": "https://github.com/freebyron/egg-sentry#readme",
   "author": "freebyron",
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included *(New changes can be covered by previous tests)*
- [ ] documentation is changed or added *(New changes can be covered by previous documentation)*
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

1. [`raven`](https://github.com/getsentry/raven-node) used by this plugin is outdated, so this PR upgrades Sentry SDK to [`@sentry/node`](https://github.com/getsentry/sentry-javascript);
2. This plugin throws error when `app.serviceClasses.sentry` does not exist (as mentioned in #2); this PR fixes this by providing a default;
3. This PR updates information in `package.json` to use issues and homepage from this repository.
